### PR TITLE
Include supported runes for launch

### DIFF
--- a/runes.schema.json
+++ b/runes.schema.json
@@ -101,7 +101,10 @@
                         "type": "integer"
                     },
                     "tx_id": {
-                        "type": "string",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
                         "minLength": 64,
                         "maxLength": 64
                     },
@@ -115,6 +118,40 @@
                 "additionalProperties": false
             }
         },
+        "allOf": [
+            {
+                "if": {
+                    "properties": {
+                        "name": {
+                            "const": "UNCOMMONGOODS"
+                        }
+                    }
+                },
+                "then": {
+                    "properties": {
+                        "location": {
+                            "properties": {
+                                "tx_id": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                },
+                "else": {
+                    "properties": {
+                        "location": {
+                            "properties": {
+                                "tx_id": {
+                                    "type": "string",
+                                    "minLength": 64
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ],
         "additionalProperties": false
     }
 }

--- a/supported_runes.json
+++ b/supported_runes.json
@@ -114,7 +114,7 @@
         "location": {
             "block_hash": "0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5",
             "block_height": 840000,
-            "tx_id": "",
+            "tx_id": null,
             "tx_index": 0,
             "timestamp": 0
         }


### PR DESCRIPTION
## Description

Adds support for the following runes:
- BILLIONDOLLARCAT
- MAGICINTERNETMONEY
- PUPSWORLDPEACE
- UNCOMMONGOODS

## Checklist

- [ ] I have added a properly formatted entry to `supported_runes.json`.
- [ ] I have validated my changes using `runes.schema.json`.
- [ ] I have tested my changes locally to ensure there are no syntax errors.
